### PR TITLE
Bugfix/fix client secret leak

### DIFF
--- a/lib/passport-tiktok/strategy.js
+++ b/lib/passport-tiktok/strategy.js
@@ -154,7 +154,7 @@ Strategy.prototype.userProfile = function(accessToken, authData, done) {
  * @api protected
  */
  Strategy.prototype.authorizationParams = function (options) {
-    return {client_key: this.options.clientID, client_secret: this.options.clientSecret};
+    return {client_key: this.options.clientID};
 };
 
 


### PR DESCRIPTION
Seems like there is a client secret leak in the authorization url

https://developers.tiktok.com/doc/login-kit-web/ <- client secret is not required